### PR TITLE
CodeBuilder.Member: fix find embed field

### DIFF
--- a/internal/bar/bar.go
+++ b/internal/bar/bar.go
@@ -37,4 +37,8 @@ func Gops_Game_New() *Game {
 	return nil
 }
 
+type Info struct {
+	id int
+}
+
 // -----------------------------------------------------------------------------

--- a/package_test.go
+++ b/package_test.go
@@ -2814,6 +2814,32 @@ func foo(t *testing.T) {
 `)
 }
 
+func TestEmbbedField(t *testing.T) {
+	pkg := newMainPackage()
+	bar := pkg.Import("github.com/goplus/gogen/internal/bar")
+	fields := []*types.Var{
+		types.NewField(token.NoPos, pkg.Types, "", bar.Ref("Info").Type(), true),
+		types.NewField(token.NoPos, pkg.Types, "id", types.Typ[types.String], false),
+	}
+	st := types.NewStruct(fields, nil)
+	typ := pkg.NewParam(token.NoPos, "t", types.NewPointer(st))
+	pkg.NewFunc(nil, "foo", types.NewTuple(typ), nil, false).BodyStart(pkg).
+		Val(ctxRef(pkg, "t")).
+		MemberRef("id").Val("0").Assign(1).
+		End()
+	domTest(t, pkg, `package main
+
+import "github.com/goplus/gogen/internal/bar"
+
+func foo(t *struct {
+	bar.Info
+	id string
+}) {
+	t.id = "0"
+}
+`)
+}
+
 func TestMemberAutoProperty(t *testing.T) {
 	pkg := newMainPackage()
 	test := pkg.Import("testing")


### PR DESCRIPTION
fix find embed field

bug main.gop
```
package main

type Info struct {
	id int
}
type T struct {
	Info
	id string
}
func demo(t *T) {
	t.id = "0"
}
func main() {
}
```
`main.gop:11:9: cannot use "0" (type untyped string) as type int in assignment`