### PR TITLE
fix getElemTypeIf check untyped float

### DIFF
--- a/template.go
+++ b/template.go
@@ -89,7 +89,7 @@ func (p *unboundProxyParam) String() string {
 
 func getElemTypeIf(t types.Type, parg *internal.Elem) types.Type {
 	if parg != nil && parg.CVal != nil {
-		if tb, ok := t.(*types.Basic); ok && (tb.Info()&types.IsFloat) != 0 {
+		if tb, ok := t.(*types.Basic); ok && tb.Kind() == types.UntypedFloat {
 			if constant.ToInt(parg.CVal).Kind() == constant.Int {
 				return types.Typ[types.UntypedInt]
 			}


### PR DESCRIPTION
fix getElemTypeIf check untyped float only.
```
//spx demo
func Rand__0(from, to int) float64
func Rand__1(from, to float64) float64

println rand(float64(2), float64(4))
```
error convert  to `Rand__0(float64(2),float64(4))`
