### PR TITLE
support typesalias

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/goplus/gogen/internal"
+	"github.com/goplus/gogen/internal/typesutil"
 )
 
 var (
@@ -168,6 +169,8 @@ retry:
 		return toObjectExpr(pkg, t.Obj())
 	case *Union:
 		return toUnionType(pkg, t)
+	case *typesutil.Alias:
+		return toObjectExpr(pkg, t.Obj())
 	}
 	log.Panicln("TODO: toType -", reflect.TypeOf(typ))
 	return nil

--- a/internal/typesutil/alias_go121.go
+++ b/internal/typesutil/alias_go121.go
@@ -1,0 +1,27 @@
+//go:build !go1.22
+// +build !go1.22
+
+package typesutil
+
+import "go/types"
+
+type Alias struct {
+}
+
+const unsupported = "typesAlias are unsupported at this go version"
+
+func (t *Alias) Underlying() types.Type {
+	panic(unsupported)
+}
+
+func (t *Alias) String() string {
+	panic(unsupported)
+}
+
+func (t *Alias) Obj() *types.TypeName {
+	panic(unsupported)
+}
+
+func NewAlias(obj *types.TypeName, rhs types.Type) *Alias {
+	return &Alias{}
+}

--- a/internal/typesutil/alias_go122.go
+++ b/internal/typesutil/alias_go122.go
@@ -1,0 +1,12 @@
+//go:build go1.22
+// +build go1.22
+
+package typesutil
+
+import "go/types"
+
+type Alias = types.Alias
+
+func NewAlias(obj *types.TypeName, rhs types.Type) *Alias {
+	return types.NewAlias(obj, rhs)
+}


### PR DESCRIPTION
fix go1.22 `GODEBUG=gotypesalias=1` types.Alias
https://github.com/goplus/gogen/issues/457