### PR TITLE
fix(CodeBuilder): prevent infinite recursion in struct field lookup

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -1142,7 +1142,7 @@ func (p addableT) Match(pkg *Package, typ types.Type) bool {
 			// TODO: refactor
 			cb := pkg.cb
 			cb.stk.Push(elemNone)
-			kind := cb.findMember(typ, "Gop_Add", "", MemberFlagVal, &Element{}, nil)
+			kind := cb.findMember(typ, "Gop_Add", "", MemberFlagVal, &Element{}, nil, nil)
 			if kind != 0 {
 				cb.stk.PopN(1)
 				if kind == MemberMethod {

--- a/codebuild_test.go
+++ b/codebuild_test.go
@@ -1,0 +1,29 @@
+package gogen
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+func TestCircularEmbeddedFieldLookup(t *testing.T) {
+	pkg := NewPackage("", "foo", nil)
+	cb := pkg.CB()
+
+	typeA := types.NewNamed(types.NewTypeName(token.NoPos, pkg.Types, "A", nil), nil, nil)
+	typeB := types.NewNamed(types.NewTypeName(token.NoPos, pkg.Types, "B", nil), nil, nil)
+
+	// Creates a circular embedding relationship between type A and B.
+	typeA.SetUnderlying(types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, pkg.Types, "", typeB, true), // Embed B.
+	}, nil))
+	typeB.SetUnderlying(types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, pkg.Types, "", typeA, true), // Embed A.
+	}, nil))
+
+	cb.stk.Push(&Element{Type: typeA})
+	kind, _ := cb.Member("any", MemberFlagVal)
+	if kind != MemberInvalid {
+		t.Fatal("Member should return MemberInvalid for circular embedding")
+	}
+}


### PR DESCRIPTION
Added `visited` map to track already processed structs in `findMember`, `embeddedField` and `field` methods to prevent stack overflow when dealing with circular struct embedding, fixing the issue reported in https://github.com/goplus/builder/issues/1199#issuecomment-2579070294.