### PR TITLE
fix `importName` for multi-import in single file

### DIFF
--- a/package.go
+++ b/package.go
@@ -167,7 +167,7 @@ func (p *File) forceImport(pkgPath string) {
 
 func (p *File) markUsed(this *Package) {
 	if p.dirty {
-		astVisitor{this}.markUsed(p.decls)
+		astVisitor{this, p}.markUsed(p.decls)
 		p.dirty = false
 	}
 }
@@ -178,7 +178,8 @@ func (p *File) Name() string {
 }
 
 type astVisitor struct {
-	this *Package
+	pkg  *Package
+	file *File
 }
 
 func (p astVisitor) Visit(node ast.Node) (w ast.Visitor) {
@@ -192,7 +193,7 @@ func (p astVisitor) Visit(node ast.Node) (w ast.Visitor) {
 		if id, ok := x.(*ast.Ident); ok && id.Obj != nil {
 			if used, ok := id.Obj.Data.(importUsed); ok && bool(!used) {
 				id.Obj.Data = importUsed(true)
-				if name, renamed := p.this.importName(id.Name); renamed {
+				if name, renamed := p.pkg.importName(p.file.Name(), id.Name); renamed {
 					id.Name = name
 					id.Obj.Name = name
 				}


### PR DESCRIPTION
In https://github.com/goplus/igop/pull/275, we use `spx@patch` to enable generic types in igop. The expected output for an spx project is:

```go
package main

import (
	"github.com/goplus/spx"
	spx1 "github.com/goplus/spx@patch"
)

func (this *Game) MainEntry() {
	// ...
	spx1.Gopt_Game_Gopx_GetWidget[spx.Monitor](this, "monitor")
	// ...
}
```

However, after https://github.com/goplus/gogen/pull/445, the spx project is compiled to:

```go
import (
	"github.com/goplus/spx"
	"github.com/goplus/spx@patch"
)

func (this *Game) MainEntry() {
	// ...
	spx.Gopt_Game_Gopx_GetWidget[spx.Monitor](this, "monitor")
	// ...
}
```

That leads to an error when running the compiled code:

```
Failed to run Go+ source: main.go:5:2: spx redeclared in this block  Code: 2
```

This PR addresses the issue by implementing import-name coordination within file.