### PR TITLE
NewFuncDef

### DIFF
--- a/builtin_test.go
+++ b/builtin_test.go
@@ -920,12 +920,12 @@ func TestCheckParenExpr(t *testing.T) {
 }
 
 func TestNoFuncName(t *testing.T) {
-	var pkg Package
 	defer func() {
 		if e := recover(); e == nil || e.(string) != "no func name" {
 			t.Fatal("TestNoFuncName failed:", e)
 		}
 	}()
+	pkg := NewPackage("", "foo", nil)
 	pkg.NewFuncWith(0, "", nil, nil)
 }
 


### PR DESCRIPTION
* allows registering an empty FuncDecl node in the AST first, followed by step-by-step initialization of its function type

This change is part of the llcppg refactoring (goplus/llcppg#157) to support function declarations to be defined first and declared later, similar to how Const and Type declarations work.