### PR TITLE
refactor: export `BoundTypeError` with `Fset` and `Pos` fields

### DIFF
--- a/builtin_test.go
+++ b/builtin_test.go
@@ -837,7 +837,7 @@ func TestTypeEx(t *testing.T) {
 			typ.Underlying()
 		}()
 	}
-	bte := &boundTypeError{tyInt, TyByte}
+	bte := &BoundTypeError{Fset: pkg.cb.fset, a: tyInt, b: TyByte}
 	if bte.Error() != "boundType int => byte failed" {
 		t.Fatal("boundTypeError:", bte)
 	}


### PR DESCRIPTION
Updates goplus/builder#1378