### PR TITLE
feat:ZeroLit for alias

### DIFF
--- a/codebuild.go
+++ b/codebuild.go
@@ -768,6 +768,9 @@ retry:
 	case *types.Named:
 		typ = p.getUnderlying(t)
 		goto retry
+	case *typesutil.Alias:
+		typ = typesutil.Unalias(t)
+		goto retry
 	}
 	ret := &ast.CompositeLit{}
 	switch t := typ.(type) {

--- a/package_test.go
+++ b/package_test.go
@@ -667,6 +667,22 @@ func main() {
 `)
 }
 
+func TestZeroLitAlias(t *testing.T) {
+	pkg := newPackage("main", true)
+	bar := pkg.AliasType("bar", types.Typ[types.Float64])
+	results := types.NewTuple(types.NewVar(token.NoPos, pkg.Types, "", bar))
+	pkg.NewFunc(nil, "foo", nil, results, false).BodyStart(pkg).
+		ZeroLit(bar).Return(1).End()
+	domTest(t, pkg, `package main
+
+type bar = float64
+
+func foo() bar {
+	return 0
+}
+`)
+}
+
 func TestZeroLitAllTypes(t *testing.T) {
 	pkg := newMainPackage()
 	tyString := types.Typ[types.String]


### PR DESCRIPTION
fix unexpected zero lit for alias type

---

without alias support in `ZeroLit`,will cause unexpect zerolit for a bulitin type's alias,like use `goplus/llgo/c.Double`
```
Error: ./cJSON.go:129:9: invalid composite literal type c.Double
Error: ./cJSON.go:406:9: invalid composite literal type c.Double
Error: /Users/runner/work/llcppg/llcppg/_llcppgtest/cjson/out/cjson/cJSON.go:129:9: invalid composite literal type float64
Error: /Users/runner/work/llcppg/llcppg/_llcppgtest/cjson/out/cjson/cJSON.go:406:9: invalid composite literal type float64
```
https://github.com/goplus/llcppg/actions/runs/14375203222/job/40305873425?pr=244

support https://github.com/goplus/llcppg/pull/244

**reproduce**
```
package main

import (
	"go/token"
	"go/types"
	"os"

	"github.com/goplus/gogen"
)

func main() {
	pkg := gogen.NewPackage("", "temp", &gogen.Config{
		EnableTypesalias: true,
	})
	clib := pkg.Import("github.com/goplus/llgo/c")
	cdouble := clib.Ref("Double").Type()
	signature := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(token.NoPos, pkg.Types, "", cdouble)), false)
	pkg.NewFuncDecl(token.NoPos, "test", signature).BodyStart(pkg).
		ZeroLit(cdouble).Return(1).End()
	pkg.WriteTo(os.Stdout)
}
```
go.mod 
```
module test

go 1.23.4

require github.com/goplus/gogen v1.16.9

require (
	github.com/goplus/llgo v0.10.0 // indirect
	golang.org/x/tools v0.19.0 // indirect
)

replace golang.org/x/tools => golang.org/x/tools v0.30.0
```

note:use `replace golang.org/x/tools => golang.org/x/tools v0.30.0` to ref a alias's name instead it's origin type.
without this `replace` the hello
```go
package temp

type hello float64
```
with this replace,we can refer the actual alias type 
```go
package temp

import "github.com/goplus/llgo/c"

type hello c.Double
```
but in this case,we will get a error zerolit of `c.Double`
```
package temp

import "github.com/goplus/llgo/c"

type hello c.Double

func test() c.Double {
        return c.Double{}
}
```
```bash
invalid composite literal type c.Double compiler[InvalidLit](https://pkg.go.dev/golang.org/x/tools/internal/typesinternal#InvalidLit)
```
with this pr,we can got a correct alias zerolit
<img width="1316" alt="image" src="https://github.com/user-attachments/assets/800be66b-3130-4ff7-8bb3-7bf15a02b837" />