### PR TITLE
fix aliasType method

### DIFF
--- a/builtin_test.go
+++ b/builtin_test.go
@@ -1429,4 +1429,26 @@ func TestBuiltinRace(t *testing.T) {
 	wg.Wait()
 }
 
+func TestAliasTypeMethod(t *testing.T) {
+	pkg := NewPackage("", "foo", nil)
+	at := types.NewPackage("foo", "foo")
+	foo := pkg.Import("github.com/goplus/gogen/internal/foo")
+	tfoo := foo.Ref("Foo").Type()
+	testcases := []struct {
+		Contract
+		typ    types.Type
+		result bool
+	}{
+		{addable, types.NewNamed(types.NewTypeName(0, at, "bar", nil), types.Typ[types.Bool], nil), false},
+		{addable, tfoo, true},
+		{addable, pkg.AliasType("Foo1", tfoo), true},
+		{addable, pkg.AliasType("Foo2", pkg.AliasType("Foo3", tfoo)), true},
+	}
+	for _, c := range testcases {
+		if c.Match(pkg, c.typ) != c.result {
+			t.Fatalf("%s.Match %v expect %v\n", c.String(), c.typ, c.result)
+		}
+	}
+}
+
 // ----------------------------------------------------------------------------

--- a/type_var_and_const.go
+++ b/type_var_and_const.go
@@ -259,11 +259,20 @@ func (p *Package) doNewType(tdecl *TypeDefs, pos token.Pos, name string, typ typ
 	decl := tdecl.decl
 	spec := &ast.TypeSpec{Name: ident(name), Assign: alias}
 	decl.Specs = append(decl.Specs, spec)
+	var methods []*types.Func
 	if alias != 0 { // alias don't need to call InitType
+		if named, ok := typ.(*types.Named); ok {
+			if n := named.NumMethods(); n != 0 {
+				methods = make([]*types.Func, n)
+				for i := 0; i < n; i++ {
+					methods[i] = named.Method(i)
+				}
+			}
+		}
 		spec.Type = toType(p, typ)
 		typ = typ.Underlying() // typ.Underlying() may delay load and can be nil, it's reasonable
 	}
-	named := types.NewNamed(typName, typ, nil)
+	named := types.NewNamed(typName, typ, methods)
 	p.useName(name)
 	return &TypeDecl{typ: named, spec: spec}
 }


### PR DESCRIPTION
fix aliasType method on unused gotypesalias

**TODO**
TestAliasTypeMethod -
测试案例里需要初始化 method 处理。
但 gop/gogen 编译里实际引用原始 type ，不需要初始 method 。