### PR TITLE
chore: replace `interface{}` with `any`

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -259,7 +259,7 @@ func toInterface(pkg *Package, t *types.Interface) ast.Expr {
 // -----------------------------------------------------------------------------
 // expression
 
-func toExpr(pkg *Package, val interface{}, src ast.Node) *internal.Elem {
+func toExpr(pkg *Package, val any, src ast.Node) *internal.Elem {
 	if val == nil {
 		return &internal.Elem{
 			Val:  identNil,
@@ -1030,7 +1030,7 @@ func matchFuncType(
 			}
 		}
 	}
-	var at interface{}
+	var at any
 	if fn == nil {
 		at = "closure argument" // fn = nil means it is a closure
 	} else {
@@ -1073,7 +1073,7 @@ func matchFuncType(
 }
 
 func matchFuncArgs(
-	pkg *Package, args []*internal.Elem, sig *types.Signature, at interface{}) error {
+	pkg *Package, args []*internal.Elem, sig *types.Signature, at any) error {
 	for i, arg := range args {
 		if err := matchType(pkg, arg, getParam(sig, i).Type(), at); err != nil {
 			return err
@@ -1150,7 +1150,7 @@ func isUnnamedParams(t *types.Tuple) bool {
 	return false
 }
 
-func matchElemType(pkg *Package, vals []*internal.Elem, elt types.Type, at interface{}) error {
+func matchElemType(pkg *Package, vals []*internal.Elem, elt types.Type, at any) error {
 	for _, val := range vals {
 		if err := matchType(pkg, val, elt, at); err != nil {
 			return err
@@ -1194,13 +1194,13 @@ type MatchError struct {
 	Src   ast.Node
 	Arg   types.Type
 	Param types.Type
-	At    interface{}
+	At    any
 
 	intr  NodeInterpreter
 	fstmt bool
 }
 
-func strval(at interface{}) string {
+func strval(at any) string {
 	switch v := at.(type) {
 	case string:
 		return v
@@ -1234,7 +1234,7 @@ func (p *MatchError) Error() string {
 }
 
 // TODO: use matchType to all assignable check
-func matchType(pkg *Package, arg *internal.Elem, param types.Type, at interface{}) error {
+func matchType(pkg *Package, arg *internal.Elem, param types.Type, at any) error {
 	if debugMatch {
 		cval := ""
 		if arg.CVal != nil {

--- a/builtin.go
+++ b/builtin.go
@@ -265,7 +265,7 @@ type typeBFunc struct {
 	result types.BasicKind
 }
 
-type xType = interface{}
+type xType = any
 type typeXParam struct {
 	name string
 	typ  xType // tidx | types.Type
@@ -455,7 +455,7 @@ func newXParamType(tparams []*TemplateParamType, x xType) types.Type {
 // ----------------------------------------------------------------------------
 
 type builtinFn struct {
-	fn   interface{}
+	fn   any
 	narg int
 }
 
@@ -1365,12 +1365,12 @@ var (
 
 // ----------------------------------------------------------------------------
 
-type bmExargs = []interface{}
+type bmExargs = []any
 
 type BuiltinMethod struct {
 	Name   string
 	Fn     types.Object
-	Exargs []interface{}
+	Exargs []any
 }
 
 func (p *BuiltinMethod) Results() *types.Tuple {

--- a/builtin_test.go
+++ b/builtin_test.go
@@ -1224,7 +1224,7 @@ func TestVarVal(t *testing.T) {
 	cb.VarVal("unknown")
 }
 
-func isError(e interface{}, msg string) bool {
+func isError(e any, msg string) bool {
 	if e != nil {
 		if err, ok := e.(error); ok {
 			return err.Error() == msg

--- a/codebuild.go
+++ b/codebuild.go
@@ -217,7 +217,7 @@ func (p *CodeBuilder) newCodeError(pos token.Pos, msg string) *CodeError {
 	return &CodeError{Msg: msg, Pos: pos, Fset: p.fset}
 }
 
-func (p *CodeBuilder) newCodeErrorf(pos token.Pos, format string, args ...interface{}) *CodeError {
+func (p *CodeBuilder) newCodeErrorf(pos token.Pos, format string, args ...any) *CodeError {
 	return p.newCodeError(pos, fmt.Sprintf(format, args...))
 }
 
@@ -225,7 +225,7 @@ func (p *CodeBuilder) handleCodeError(pos token.Pos, msg string) {
 	p.handleErr(p.newCodeError(pos, msg))
 }
 
-func (p *CodeBuilder) handleCodeErrorf(pos token.Pos, format string, args ...interface{}) {
+func (p *CodeBuilder) handleCodeErrorf(pos token.Pos, format string, args ...any) {
 	p.handleErr(p.newCodeError(pos, fmt.Sprintf(format, args...)))
 }
 
@@ -233,7 +233,7 @@ func (p *CodeBuilder) panicCodeError(pos token.Pos, msg string) {
 	panic(p.newCodeError(pos, msg))
 }
 
-func (p *CodeBuilder) panicCodeErrorf(pos token.Pos, format string, args ...interface{}) {
+func (p *CodeBuilder) panicCodeErrorf(pos token.Pos, format string, args ...any) {
 	panic(p.newCodeError(pos, fmt.Sprintf(format, args...)))
 }
 
@@ -701,11 +701,11 @@ func (p *CodeBuilder) NewAutoVar(pos token.Pos, name string, pv **types.Var) *Co
 }
 
 // VarRef func: p.VarRef(nil) means underscore (_)
-func (p *CodeBuilder) VarRef(ref interface{}, src ...ast.Node) *CodeBuilder {
+func (p *CodeBuilder) VarRef(ref any, src ...ast.Node) *CodeBuilder {
 	return p.doVarRef(ref, getSrc(src), true)
 }
 
-func (p *CodeBuilder) doVarRef(ref interface{}, src ast.Node, allowDebug bool) *CodeBuilder {
+func (p *CodeBuilder) doVarRef(ref any, src ast.Node, allowDebug bool) *CodeBuilder {
 	if ref == nil {
 		if allowDebug && debugInstr {
 			log.Println("VarRef _")
@@ -1382,7 +1382,7 @@ func (p *CodeBuilder) VarVal(name string, src ...ast.Node) *CodeBuilder {
 }
 
 // Val func
-func (p *CodeBuilder) Val(v interface{}, src ...ast.Node) *CodeBuilder {
+func (p *CodeBuilder) Val(v any, src ...ast.Node) *CodeBuilder {
 	if debugInstr {
 		if o, ok := v.(types.Object); ok {
 			log.Println("Val", o.Name(), o.Type())
@@ -1402,7 +1402,7 @@ func (p *CodeBuilder) Val(v interface{}, src ...ast.Node) *CodeBuilder {
 	return p.pushVal(v, getSrc(src))
 }
 
-func (p *CodeBuilder) pushVal(v interface{}, src ast.Node) *CodeBuilder {
+func (p *CodeBuilder) pushVal(v any, src ast.Node) *CodeBuilder {
 	p.stk.Push(toExpr(p.pkg, v, src))
 	return p
 }
@@ -2209,7 +2209,7 @@ retry:
 //   - cb.UnaryOp(op token.Token)
 //   - cb.UnaryOp(op token.Token, twoValue bool)
 //   - cb.UnaryOp(op token.Token, twoValue bool, src ast.Node)
-func (p *CodeBuilder) UnaryOp(op token.Token, params ...interface{}) *CodeBuilder {
+func (p *CodeBuilder) UnaryOp(op token.Token, params ...any) *CodeBuilder {
 	var src ast.Node
 	var flags InstrFlags
 	switch len(params) {

--- a/error_msg_test.go
+++ b/error_msg_test.go
@@ -49,7 +49,7 @@ var (
 )
 
 // text, line, column
-func source(text string, args ...interface{}) ast.Node {
+func source(text string, args ...any) ast.Node {
 	if len(args) < 2 {
 		return &txtNode{Msg: text}
 	}

--- a/internal/builtin/big.go
+++ b/internal/builtin/big.go
@@ -29,7 +29,7 @@ const (
 
 type Gop_ninteger = uint
 
-func Gop_istmp(a interface{}) bool {
+func Gop_istmp(a any) bool {
 	return false
 }
 

--- a/internal/go/format/format.go
+++ b/internal/go/format/format.go
@@ -51,7 +51,7 @@ const parserMode = parser.ParseComments
 //
 // The function may return early (before the entire result is written)
 // and return a formatting error, for instance due to an incorrect AST.
-func Node(dst io.Writer, fset *token.FileSet, node interface{}) error {
+func Node(dst io.Writer, fset *token.FileSet, node any) error {
 	// Determine if we have a complete source file (file != nil).
 	var file *ast.File
 	var cnode *printer.CommentedNode

--- a/internal/go/printer/printer.go
+++ b/internal/go/printer/printer.go
@@ -104,7 +104,7 @@ func (p *printer) init(cfg *Config, fset *token.FileSet, nodeSizes map[ast.Node]
 	p.cachedPos = -1
 }
 
-func (p *printer) internalError(msg ...interface{}) {
+func (p *printer) internalError(msg ...any) {
 	if debug {
 		fmt.Print(p.pos.String() + ": ")
 		fmt.Println(msg...)
@@ -877,7 +877,7 @@ func (p *printer) setPos(pos token.Pos) {
 // taking into account the amount and structure of any pending white-
 // space for best comment placement. Then, any leftover whitespace is
 // printed, followed by the actual token.
-func (p *printer) print(args ...interface{}) {
+func (p *printer) print(args ...any) {
 	for _, arg := range args {
 		// information about the current arg
 		var data string
@@ -1073,7 +1073,7 @@ func getLastComment(n ast.Node) *ast.CommentGroup {
 	return nil
 }
 
-func (p *printer) printNode(node interface{}) error {
+func (p *printer) printNode(node any) error {
 	// unpack *CommentedNode, if any
 	var comments []*ast.CommentGroup
 	if cnodes, ok := node.(*CommentedNodes); ok {
@@ -1307,7 +1307,7 @@ type Config struct {
 }
 
 // fprint implements Fprint and takes a nodesSizes map for setting up the printer state.
-func (cfg *Config) fprint(output io.Writer, fset *token.FileSet, node interface{}, nodeSizes map[ast.Node]int) (err error) {
+func (cfg *Config) fprint(output io.Writer, fset *token.FileSet, node any, nodeSizes map[ast.Node]int) (err error) {
 	// print node
 	var p printer
 	p.init(cfg, fset, nodeSizes)
@@ -1358,13 +1358,13 @@ func (cfg *Config) fprint(output io.Writer, fset *token.FileSet, node interface{
 // A CommentedNode bundles an AST node and corresponding comments.
 // It may be provided as argument to any of the Fprint functions.
 type CommentedNode struct {
-	Node     interface{} // *ast.File, or ast.Expr, ast.Decl, ast.Spec, or ast.Stmt
+	Node     any // *ast.File, or ast.Expr, ast.Decl, ast.Spec, or ast.Stmt
 	Comments []*ast.CommentGroup
 }
 
 // by Go+
 type CommentedNodes struct {
-	Node           interface{}
+	Node           any
 	CommentedStmts map[ast.Stmt]*ast.CommentGroup
 }
 
@@ -1372,7 +1372,7 @@ type CommentedNodes struct {
 // Position information is interpreted relative to the file set fset.
 // The node type must be *ast.File, *CommentedNode, []ast.Decl, []ast.Stmt,
 // or assignment-compatible to ast.Expr, ast.Decl, ast.Spec, or ast.Stmt.
-func (cfg *Config) Fprint(output io.Writer, fset *token.FileSet, node interface{}) error {
+func (cfg *Config) Fprint(output io.Writer, fset *token.FileSet, node any) error {
 	return cfg.fprint(output, fset, node, make(map[ast.Node]int))
 }
 
@@ -1380,6 +1380,6 @@ func (cfg *Config) Fprint(output io.Writer, fset *token.FileSet, node interface{
 // It calls Config.Fprint with default settings.
 // Note that gofmt uses tabs for indentation but spaces for alignment;
 // use format.Node (package go/format) for output that matches gofmt.
-func Fprint(output io.Writer, fset *token.FileSet, node interface{}) error {
+func Fprint(output io.Writer, fset *token.FileSet, node any) error {
 	return (&Config{Tabwidth: 8}).Fprint(output, fset, node)
 }

--- a/internal/typeparams/normalize.go
+++ b/internal/typeparams/normalize.go
@@ -120,7 +120,7 @@ type termSet struct {
 	terms    termlist
 }
 
-func indentf(depth int, format string, args ...interface{}) {
+func indentf(depth int, format string, args ...any) {
 	fmt.Fprintf(os.Stderr, strings.Repeat(".", depth)+format+"\n", args...)
 }
 

--- a/type_ext.go
+++ b/type_ext.go
@@ -261,7 +261,7 @@ func (p *unboundMapElemType) String() string {
 
 type btiMethodType struct {
 	types.Type
-	eargs []interface{}
+	eargs []any
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Script used:

```
gofmt -r 'interface{} -> any' -w .
```